### PR TITLE
Updated Serial Monitor to have 74880 as an option.

### DIFF
--- a/lib/serial-monitor/template.html
+++ b/lib/serial-monitor/template.html
@@ -23,6 +23,7 @@
         <option value="28800">28800</option>
         <option value="38400">38400</option>
         <option value="57600">57600</option>
+        <option value="74880">74880</option>
         <option value="115200">115200</option>
         <option value="230400">230400</option>
       </select>


### PR DESCRIPTION
esp8266's use this baudrate to send bootloader messages.
I know its not ideal but it can't be changed.
