### PR TITLE
Update only autoRunCommand when it's undefined

### DIFF
--- a/lib/maintenance.js
+++ b/lib/maintenance.js
@@ -56,7 +56,7 @@ export function updateOSEnviron() {
 
   // export PATH to PlatformIO IDE Terminal
   let terminal_autorun_key = 'platformio-ide-terminal.core.autoRunCommand';
-  if (!config.IS_WINDOWS && !atom.config.get(terminal_autorun_key)) {
+  if (!config.IS_WINDOWS && atom.config.get(terminal_autorun_key) === undefined) {
     if (process.env.SHELL && process.env.SHELL.indexOf('fish') !== -1) {
       atom.config.set(
         terminal_autorun_key,


### PR DESCRIPTION
So it's possible to set that to empty command when we don't need to set the path (ie. platformio installed globally).