### PR TITLE
add various baudrates to serial-monitor

### DIFF
--- a/lib/serial-monitor/template.html
+++ b/lib/serial-monitor/template.html
@@ -23,8 +23,12 @@
         <option value="28800">28800</option>
         <option value="38400">38400</option>
         <option value="57600">57600</option>
+        <option value="74880">74880</option>
         <option value="115200">115200</option>
         <option value="230400">230400</option>
+        <option value="250000">250000</option>
+        <option value="460800">460800</option>
+        <option value="921600">921600</option>
       </select>
     </div>
 


### PR DESCRIPTION
some platforms/boards (such as esp8266) use varius uncommon baudrates,
here we just add them.

baudrates added: 74880, 250000, 460800, 921600