### PR TITLE
Skip editors with undefined paths

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -182,8 +182,13 @@ class PlatformIOIDEPackage {
     }));
 
     this.subscriptions.add(atom.workspace.observeTextEditors((editor) => {
+      const editorPath = editor.getPath();
+      if (!editorPath) {
+        return;
+      }
+
       // Handle *.ino and *.pde files as C++
-      var extname = path.extname(editor.getPath());
+      const extname = path.extname(editorPath);
       if (['.ino', '.pde'].indexOf(extname) !== -1) {
         editor.setGrammar(atom.grammars.grammarForScopeName('source.cpp'));
         maintenance.notifyLinterDisabledforArduino();
@@ -192,7 +197,7 @@ class PlatformIOIDEPackage {
         maintenance.checkClang();
       }
 
-      if ('platformio.ini' === path.basename(editor.getPath())) {
+      if ('platformio.ini' === path.basename(editorPath)) {
         editor.onDidSave(() => utils.runAtomCommand('build:refresh-targets'));
       }
     }));


### PR DESCRIPTION
An editor may not have a path in case it has not been saved to file system, and therefore they cannot possibly have a name and an extension.