### PR TITLE
Fixed virtualenv.py execution finished with errors and incomplete python environment

### DIFF
--- a/lib/installer/stages/platformio-core.js
+++ b/lib/installer/stages/platformio-core.js
@@ -81,7 +81,11 @@ export default class PlatformIOCoreStage extends BaseStage {
     return null;
   }
 
-  async installPythonForWindows() {
+  /* Param administrative: When true, the installation requires administrator rights, however the MSI will be installed also if python is
+   * already installed somewhere on the system. If false, then classic user MSI installation is done, which means that if there is already installed
+   * python, this installation will finish without installing the msi into the ../penv/python27 folder => Couldn't install Python with MSI error.
+   */
+  async installPythonForWindows(administrative = false) {
     // https://www.python.org/ftp/python/2.7.13/python-2.7.13.msi
     // https://www.python.org/ftp/python/2.7.13/python-2.7.13.amd64.msi
     const pythonArch = process.arch === 'x64' ? '.amd64' : '';
@@ -98,7 +102,7 @@ export default class PlatformIOCoreStage extends BaseStage {
       await new Promise((resolve, reject) => {
         utils.runCommand(
           'msiexec.exe',
-          ['/i', msiInstaller, '/qn', '/li', logFile, `TARGETDIR=${targetDir}`],
+          [administrative ? '/a' : '/i', msiInstaller, '/qn', '/li', logFile, `TARGETDIR=${targetDir}`],
           (code, stdout, stderr) => {
             if (code === 0) {
               return resolve(stdout);
@@ -359,7 +363,18 @@ export default class PlatformIOCoreStage extends BaseStage {
         await this.createVirtualenvWithUser(pythonExecutable);
       } catch (err) {
         console.error(err);
-        await this.createVirtualenvWithDownload(pythonExecutable);
+        try{
+          await this.createVirtualenvWithDownload(pythonExecutable);
+        } catch (err) {
+          console.error(err);
+          // If we are on Windows try installing local copy of Python, because already installed python wasn't able to run virutalenv.py
+          if(config.IS_WINDOWS) {
+            const localPythonExecutable = await this.installPythonForWindows(true);
+            await this.createVirtualenvWithDownload(localPythonExecutable);
+          }else{
+            throw new Error(err);
+          }
+        }
       }
     }
 


### PR DESCRIPTION
This request addresses the problem described in #336 and #337, which I've had myself.
### The Problem
When you have Atom installed and want to install PlatformIO, during the installation an error appears, which states that Python couldn't import `functools` because no such module exists. The `functools` is a builtin library which is imported by default, so it means that the Python interpeter is not correctly installed.

### What causes this problem?
When the installer determines it needs to setup the virtualenv using the `virtualenv.py` script and the user has already python installed, then if the Python was installed "only for this user", the `virtualenv.py` execution finishes with errors and not functioning Python installation (the cause of missing `functools`). 

### The proposed solution
We wait for the return code of `virtualenv.py` execution and if it fails (the code isn't 0), than we `installPythonForWindows` and retry with the fresh Python installation.

#### Note
When there is already Python 2.7.13 installed (even if it isn't able to sucessfully run the `virtualenv.py`) than the `installPythonForWindows` fails, because the MSI installer detects existing installation of Python on Windows. To go around this, use the `/a` switch when running `msiexec.exe` instead of the default `/i`. Basically, this installs the MSI with administrative rights, and doesn't care if there is existing installation present.