### PR TITLE
Avoid unnecessary realpath() calls

### DIFF
--- a/lib/maintenance.js
+++ b/lib/maintenance.js
@@ -157,13 +157,9 @@ export function highlightActiveProject(isEnabled = true, retries = 3) {
 
   dirs.forEach((dir) => {
     dir.classList.remove('pio-active-directory');
-    if (!dir.dataset.pioRealpath) {
+    if (!dir.dataset.pioProjectPath) {
       const span = dir.querySelector('.header > span[data-path]');
-      try {
-        dir.dataset.pioRealpath = fs.realpathSync(span.dataset.path);
-      } catch (e) {
-        dir.dataset.pioRealpath = span.dataset.path;
-      }
+      dir.dataset.pioProjectPath = span.dataset.path;
     }
   });
   if (dirs.length < 2 || !isEnabled || !p) {
@@ -172,7 +168,7 @@ export function highlightActiveProject(isEnabled = true, retries = 3) {
 
   let done = false;
   for (const dir of dirs) {
-    if (dir.dataset.pioRealpath === p.toString()) {
+    if (dir.dataset.pioProjectPath === p.toString()) {
       dir.classList.add('pio-active-directory');
       done = true;
       break;

--- a/lib/services/build.js
+++ b/lib/services/build.js
@@ -63,11 +63,7 @@ export default class BuildProvider {
   ];
 
   constructor(cwd) {
-    try {
-      this.projectDir = fs.realpathSync(cwd);
-    } catch (e) {
-      this.projectDir = cwd;
-    }
+    this.projectDir = cwd;
   }
 
   getNiceName() {


### PR DESCRIPTION
According to atom/atom#9879, TextEditor.getPath() does not return a realpath
since Atom 1.14. We no longer need to normalize paths by calling realpath() in
order to determine the active project, and we can use the actual project paths
and text editor paths instead.

Resolve #136, Resolve #320.