### PR TITLE
Put .platformio to disk root when path contains non-ASCII characters

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -109,8 +109,8 @@ export const ATOM_CONFIG = {
 export const IS_WINDOWS = process.platform.startsWith('win');
 export const PKG_BASE_DIR = path.resolve(path.dirname(__filename), '..');
 export const CACHE_DIR = path.join(PKG_BASE_DIR, '.cache');
-export const PIO_HOME_DIR = process.env.PLATFORMIO_HOME_DIR ? process.env.PLATFORMIO_HOME_DIR : path.join(fs.getHomeDirectory(), '.platformio');
-export const ENV_DIR = _get_env_dir(path.join(PIO_HOME_DIR, 'penv'));
+export const PIO_HOME_DIR = _getPioHomeDir(process.env.PLATFORMIO_HOME_DIR || path.join(fs.getHomeDirectory(), '.platformio'));
+export const ENV_DIR = path.join(PIO_HOME_DIR, 'penv');
 export const ENV_BIN_DIR = path.join(ENV_DIR, IS_WINDOWS ? 'Scripts' : 'bin');
 
 export const ATOM_DEPENDENCIES = {
@@ -183,22 +183,21 @@ export const INPUT_FILTER_DELAY = 200; // ms, dalay before filtering projects, l
 
 export const PLATFORMIO_API_ENDPOINT = 'http://api.platformio.org';
 
-
-function _get_env_dir(defaultEnvDir) {
+function _getPioHomeDir(pioHomeDir) {
   if (IS_WINDOWS) {
-    // Put the env directory to the root of the current local disk when
-    // default path contains non-ASCII characters. Virtualenv will fail to
-    for (const char of defaultEnvDir) {
+    // Make sure that all path characters have valid ASCII codes.
+    for (const char of pioHomeDir) {
       if (char.charCodeAt(0) > 127) {
-        const defaultEnvDirFormat = path.parse(defaultEnvDir);
+        // If they don't, put the pio home directory into the root of the disk.
+        const homeDirPathFormat = path.parse(pioHomeDir);
         return path.format({
-          root: defaultEnvDirFormat.root,
-          dir: defaultEnvDirFormat.root,
-          base: '.pioidepenv',
-          name: '.pioidepenv',
+          root: homeDirPathFormat.root,
+          dir: homeDirPathFormat.root,
+          base: '.platformio',
+          name: '.platformio',
         });
       }
     }
   }
-  return defaultEnvDir;
+  return pioHomeDir;
 }


### PR DESCRIPTION
Resolve #321