### PR TITLE
Fixed Virtualenv Download: ImportError: No module named functools

### DIFF
--- a/lib/installer/stages/platformio-core.js
+++ b/lib/installer/stages/platformio-core.js
@@ -368,7 +368,18 @@ export default class PlatformIOCoreStage extends BaseStage {
         await this.createVirtualenvWithUser(pythonExecutable);
       } catch (err) {
         console.error(err);
-        await this.createVirtualenvWithDownload(pythonExecutable);
+        try{
+          await this.createVirtualenvWithDownload(pythonExecutable);
+        } catch (err) {
+          console.error(err);
+          // If we are on Windows try installing local copy of Python, because already installed python wasn't able to run virutalenv.py
+          if(config.IS_WINDOWS) {
+            const localPythonExecutable = await this.installPythonForWindows();
+            await this.createVirtualenvWithDownload(localPythonExecutable);
+          }else{
+            throw new Error(err);
+          }
+        }
       }
     }
 


### PR DESCRIPTION
Check if the `virtualenv` was set up properly, if not, install local copy of Python 2.7 from MSI, which will ensure that the interpreter will have everything what is needed for the `virtualenv.py` execution.
Resolves  #337.