### PR TITLE
Don't override a user's preferences after every update.

### DIFF
--- a/lib/installer/stages/configuration.js
+++ b/lib/installer/stages/configuration.js
@@ -58,9 +58,6 @@ export default class ConfigurationStage extends BaseStage {
   }
 
   install() {
-    // force PIO Home after upgrade
-    atom.config.set('platformio-ide.showPIOHome', true);
-
     // cleanup not used config and storage items
     ConfigurationStage.OBSOLATE_STORAGE_ITEMS.forEach(key => localStorage.removeItem(key));
     ConfigurationStage.OBSOLATE_CONFIG_ITEMS.forEach(key => atom.config.get(key) ? atom.config.set(key, undefined) : '');


### PR DESCRIPTION
This solves an issue I tweeted about here
https://twitter.com/bmv437/status/874766719046299648

After every PlatformIO-IDE update, it resets my preferences to hide the PlatformIO Home screen, which is undesirable. I as well as others use Atom for more than just PlatformIO development, and I don't know of any other Atom package that resets user preferences after each update.

![image](https://user-images.githubusercontent.com/1403707/27109442-e7048a94-5070-11e7-9a6a-8429d7133f1a.png)
