### PR TITLE
Fix clang code completion instructions link

### DIFF
--- a/lib/installer/stages/code-completion-engine.js
+++ b/lib/installer/stages/code-completion-engine.js
@@ -57,7 +57,7 @@ export default class CodeCompletionEngineStage extends BaseStage {
     });
     switch (selected) {
       case 0:
-        utils.openUrl('http://docs.platformio.org/page/ide/atom.html#clang-for-intelligent-code-completion');
+        utils.openUrl('http://docs.platformio.org/page/ide/atom.html#ii-clang-for-intelligent-code-completion');
         throw new Error('Clang is not installed in your system');
 
       case 2:


### PR DESCRIPTION
The original URL is not valid a valid anchor link and will not cause the browser to automatically scroll to the expected section.